### PR TITLE
Use spin variables rather than binary variables

### DIFF
--- a/hamiltonian/field.py
+++ b/hamiltonian/field.py
@@ -1,12 +1,14 @@
 import minimization.variable
-from minimization.weight import AccumulatingWeightMatrix
+from minimization.weight import BiasAccumulator
 
 class FieldAtPoint:
     """
     This class represents the strength of a QFT scalar field at a point in
-    space-time using binary variables in the Ising chain domain wall model.
-    The field takes (number_of_values_for_field + 1) binary variables so that
-    there can be a single domain wall.
+    space-time using spin variables in the Ising chain domain wall model. The
+    field takes (number_of_values_for_field + 1) spin variables so that there
+    can be a single domain wall, with down spins (normally represented as |1> or
+    sometimes informally as 1) on the lower-index side and up spins (|0> or 0)
+    on the higher-index side.
     """
     def __init__(
             self,
@@ -17,9 +19,10 @@ class FieldAtPoint:
             field_step_in_GeV: float
         ):
         """
-        The constructor just sets up the names for the binary variables, since
-        the D-Wave samplers just want dicts of names of binary variables or
-        pairs of names of binary variables, mapped to weights.
+        The constructor just sets up the names for the spin variables, since the
+        sample_ising methods of D-Wave samplers just want dicts of names of spin
+        variables mapped to linear biases and dicts of pairs of names of spin
+        variables mapped to quadratic biases.
         """
         if number_of_values_for_field < 2:
             raise ValueError("Need a range of at least 2 values for the field")
@@ -31,44 +34,48 @@ class FieldAtPoint:
             f"{field_name}_{spatial_point_identifier}_",
             number_of_values_for_field - 1
         )
-        # We need a binary variable fixed to 1 at the start and another fixed to
-        # 0 at the end, in addition to the variables which can actually vary.
+        # We need a binary variable fixed to |1> at the start and another fixed
+        # to |0> at the end, in addition to the variables which can actually
+        # vary.
         self.binary_variable_names = [
             name_function(i) for i in range(number_of_values_for_field + 1)
         ]
         self.field_step_in_GeV = field_step_in_GeV
 
-    def weights_for_ICDW(
+    def domain_wall_weights(
             self,
             *,
             end_spin_weight: float,
             spin_alignment_weight: float
-        ) -> AccumulatingWeightMatrix:
+        ) -> BiasAccumulator:
         """
-        This returns the matrix of weights in the form expected by D-Wave Ocean
-        stuff: an upper-triangular matrix of correlation weights, where the
-        diagonal elements are understood to be actually the weights of the
-        linear terms.
+        This returns the weights in the form for sample_ising: a dict of linear
+        biases, which could be represented by a vector, and a dict of quadratic
+        biases, which could be represented as an upper-triangular matrix of
+        correlation weights, with zeros on the diagonal.
         """
-        # We could do this with fewer assignments, but it won't be the
-        # bottleneck while it is important to make sure that it is correct.
         # First, we set the weights to fix the ends so that there is a domain of
         # 1s from the first index and a domain of 0s ending at the last index.
+        # The signs are this way because we want the first spin to be |1> which
+        # multiplies its weight by -1 in the objective function, and the last
+        # spin to be |0> which multiplies its weight by +1.
         first_variable = self.binary_variable_names[0]
         last_variable = self.binary_variable_names[-1]
-        weights_matrix = AccumulatingWeightMatrix({
-            (first_variable, first_variable): -end_spin_weight,
-            (last_variable, last_variable): end_spin_weight
-        })
-        # Next, each pair of nearest neighbors gets weighted to favor same
-        # values, by penalizing each individual but with a cancelling weight for
-        # when both are 1. (There is nothing to cancel if both are 0.)
+        model_biases = BiasAccumulator(
+            initial_linears={
+                first_variable: end_spin_weight,
+                last_variable: -end_spin_weight
+            }
+        )
+        # Next, each pair of nearest neighbors gets weighted to favor having the
+        # same values - which is either (-1)^2 or (+1)^2, so +1, while opposite
+        # values multiply the weighting by (-1) * (+1) = -1. Therefore, a
+        # negative weighting will penalize opposite spins with a positive
+        # contribution to the objective function.
         lower_variable = first_variable
         for higher_variable in self.binary_variable_names[1:]:
-            weights_matrix.add({
-                (lower_variable, lower_variable): spin_alignment_weight,
-                (lower_variable, higher_variable): -2.0 * spin_alignment_weight,
-                (higher_variable, higher_variable): spin_alignment_weight
+            model_biases.add_quadratics({
+                (lower_variable, higher_variable): -spin_alignment_weight
             })
             lower_variable = higher_variable
-        return weights_matrix
+        return model_biases

--- a/hamiltonian/potential.py
+++ b/hamiltonian/potential.py
@@ -1,16 +1,16 @@
-from minimization.weight import AccumulatingWeightMatrix
+from minimization.weight import BiasAccumulator
 from hamiltonian.field import FieldAtPoint
 from configuration.configuration import DiscreteConfiguration
 
 def weights_for(
         configuration: DiscreteConfiguration,
         single_field: FieldAtPoint
-    ) -> AccumulatingWeightMatrix:
+    ) -> BiasAccumulator:
         """
-        This function adds calculates weights for binary variables of a single
-        field represented by a set of IcdwFields, one for every spatial point.
-        (The calculation is significantly different when dealing with multiple
-        fields at a single spatial point.)
+        This function adds calculates weights for spin variables of a single
+        field represented by a set of FieldAtPoint objects, one for every
+        spatial point. (The calculation is significantly different when dealing
+        with multiple fields at a single spatial point.)
         """
         potential_values = configuration.potential_in_quartic_GeV_per_field_step
         number_of_potential_values = len(potential_values)
@@ -24,16 +24,25 @@ def weights_for(
                 f"Provided {number_of_potential_values} values for potential"
                 f" but {number_of_field_values} values for field"
             )
-        weight_matrix = {}
-        # We never actually use the first value of the potential - its constant
-        # value is implicitly subtracted from the Hamiltonian. So if we have 4
-        # values U_0, U_1, U_2, and U_3, the field has 5 binary variables, where
-        # the first and last are fixed, and bitstrings 10000 has implicit value
-        # 0 = U_0 - U_0, 11000 has U_1 - U_0, 11100 has U_2 - U_1, and 11110 has
-        # U_3 - U_2. (There are no other valid bitstrings for this field.)
+        linear_weights = {}
+        # If we have 4 values U_0, U_1, U_2, and U_3, the field has 5 binary
+        # variables, where the first and last are fixed, and there are 4 valid
+        # bitstrings: 10000, 11000, 11100, and 11110. If the middle 3 spin
+        # variables have weights A, B, and C respectively, then we have the
+        # following simultaneous equations when considering the weights brought
+        # to the objective function:
+        # +A+B+C = U_0
+        # -A+B+C = U_1
+        # -A-B+C = U_2
+        # -A-B-C = U_3
+        # Therefore,
+        # U_3 - U_2 = -2 C
+        # U_2 - U_1 = -2 B
+        # U_1 - U_0 = -2 A
+        # and so we end up with the factor 0.5 and the potential for the lower
+        # index minus the potential for the higher index.
         for i in range(1, number_of_field_values):
-            variable_name = single_field.binary_variable_names[i]
-            weight_matrix[(variable_name, variable_name)] = (
-                potential_values[i] - potential_values[i - 1]
+            linear_weights[single_field.binary_variable_names[i]] = (
+                0.5 * (potential_values[i - 1] - potential_values[i])
             )
-        return AccumulatingWeightMatrix(weight_matrix)
+        return BiasAccumulator(initial_linears=linear_weights)

--- a/hamiltonian/test_potential.py
+++ b/hamiltonian/test_potential.py
@@ -1,7 +1,8 @@
 from typing import Callable, Tuple
 import unittest
 from dimod import ExactSolver
-from minimization.weight import AccumulatingWeightMatrix
+import minimization.variable
+from minimization.weight import BiasAccumulator
 from configuration.configuration import DiscreteConfiguration
 from structure.bubble import BubbleProfile
 from hamiltonian.field import FieldAtPoint
@@ -12,54 +13,59 @@ class TestSingleFieldPotential(unittest.TestCase):
     def test_proportional_to_field_value(self):
         def linear_potential(field_value: int):
             return (2.5 * field_value) + 10.0
-        _, actual_weights = self.for_single_test_field(
+        _, actual_weights = self._for_single_test_field(
             single_field_potential=linear_potential,
             number_of_potential_values=5
         )
-        actual_weight_matrix = actual_weights.weight_matrix
+        actual_linear_weights = actual_weights.linear_biases
 
-        # The weights are actually just the differences which each 0 flipping to
-        # a 1 brings.
-        expected_weights = {
-            ("T_r0_1", "T_r0_1"): 2.5,
-            ("T_r0_2", "T_r0_2"): 2.5,
-            ("T_r0_3", "T_r0_3"): 2.5,
-            ("T_r0_4", "T_r0_4"): 2.5,
+        # The weights are actually just the differences which each |0> flipping
+        # to a |1> brings (with a factor of -0.5 because the spin flip itself
+        # brings a factor of (-1)-(+1) = -2).
+        expected_linear_weights = {
+            "T_r0_1": -1.25,
+            "T_r0_2": -1.25,
+            "T_r0_3": -1.25,
+            "T_r0_4": -1.25,
         }
         self.assertEqual(
-            expected_weights.keys(),
-            actual_weight_matrix.keys()
+            expected_linear_weights.keys(),
+            actual_linear_weights.keys()
         )
-        for expected_key in expected_weights.keys():
+        for expected_key in expected_linear_weights.keys():
             self.assertAlmostEqual(
-                expected_weights[expected_key],
-                actual_weight_matrix.get(expected_key, 0.0),
-                msg=f"incorrect weight for {expected_key}"
+                expected_linear_weights[expected_key],
+                actual_linear_weights.get(expected_key, 0.0),
+                msg=f"incorrect linear weight for {expected_key}"
             )
 
     def test_linear_potential_minimized_correctly(self):
         # In this case as well, the linear term is irrelevant.
         def linear_potential(field_value: int):
             return (2.0 * field_value) + 20.0
-        test_field, potential_weights = self.for_single_test_field(
+        test_field, potential_weights = self._for_single_test_field(
             single_field_potential=linear_potential,
             number_of_potential_values=7
         )
         test_sampler = ExactSolver()
         end_weight = 10.0
         alignment_weight = 3.5
-        weight_accumulator = test_field.weights_for_ICDW(
+        weight_accumulator = test_field.domain_wall_weights(
                 end_spin_weight=end_weight,
                 spin_alignment_weight=alignment_weight
             )
-        weight_accumulator.add(potential_weights.weight_matrix)
+        weight_accumulator.add(potential_weights)
 
-        sampling_result = test_sampler.sample_qubo(
-            weight_accumulator.weight_matrix
+        sampling_result = test_sampler.sample_ising(
+            h=weight_accumulator.linear_biases,
+            J=weight_accumulator.quadratic_biases
         )
         lowest_energy = sampling_result.lowest(rtol=0.01, atol=0.1)
         bitstrings_to_energies = {
-            "".join([f"{s[n]}" for n in test_field.binary_variable_names]): e
+            minimization.variable.as_bitstring(
+                spin_variable_names=test_field.binary_variable_names,
+                spin_mapping=s
+            ): e
             for s, e in [(d.sample, d.energy) for d in lowest_energy.data()]
         }
 
@@ -79,25 +85,29 @@ class TestSingleFieldPotential(unittest.TestCase):
         # As ever, the linear term is irrelevant.
         def quadratic_potential(field_value: int):
             return (2.5 * (field_value - 5) * (field_value - 5)) + 10.0
-        test_field, potential_weights = self.for_single_test_field(
+        test_field, potential_weights = self._for_single_test_field(
             single_field_potential=quadratic_potential,
             number_of_potential_values=7
         )
         test_sampler = ExactSolver()
         end_weight = 10.0
         alignment_weight = 3.5
-        weight_accumulator = test_field.weights_for_ICDW(
+        weight_accumulator = test_field.domain_wall_weights(
                 end_spin_weight=end_weight,
                 spin_alignment_weight=alignment_weight
             )
-        weight_accumulator.add(potential_weights.weight_matrix)
+        weight_accumulator.add(potential_weights)
 
-        sampling_result = test_sampler.sample_qubo(
-            weight_accumulator.weight_matrix
+        sampling_result = test_sampler.sample_ising(
+            h=weight_accumulator.linear_biases,
+            J=weight_accumulator.quadratic_biases
         )
         lowest_energy = sampling_result.lowest(rtol=0.01, atol=0.1)
         bitstrings_to_energies = {
-            "".join([f"{s[n]}" for n in test_field.binary_variable_names]): e
+            minimization.variable.as_bitstring(
+                spin_variable_names=test_field.binary_variable_names,
+                spin_mapping=s
+            ): e
             for s, e in [(d.sample, d.energy) for d in lowest_energy.data()]
         }
 
@@ -113,12 +123,12 @@ class TestSingleFieldPotential(unittest.TestCase):
             "expected 5 1s between fixed 1st bit and domain wall"
         )
 
-    def for_single_test_field(
+    def _for_single_test_field(
             self,
             *,
             single_field_potential: Callable[[int], float],
             number_of_potential_values: int
-        ) -> Tuple[FieldAtPoint, AccumulatingWeightMatrix]:
+        ) -> Tuple[FieldAtPoint, BiasAccumulator]:
         discretized_potential = [
             single_field_potential(f) for f in range(number_of_potential_values)
         ]

--- a/minimization/variable.py
+++ b/minimization/variable.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Dict, List
 
 def name_for_index(
         name_prefix: str,
@@ -9,3 +9,15 @@ def name_for_index(
         numeric_part = "{0:0{n}}".format(specific_index, n=number_of_digits)
         return f"{name_prefix}{numeric_part}"
     return specific_function
+
+def spin_to_zero_or_one(spin_value: int) -> str:
+    return "0" if spin_value > 0 else "1"
+
+def as_bitstring(
+        *,
+        spin_variable_names: List[str],
+        spin_mapping: Dict[str, int]
+    ) -> str:
+    return "".join(
+        [spin_to_zero_or_one(spin_mapping[n]) for n in spin_variable_names]
+    )

--- a/minimization/weight.py
+++ b/minimization/weight.py
@@ -1,13 +1,36 @@
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple, TypeVar
 
-class AccumulatingWeightMatrix:
-    """
-    This class encapsulates the aggregation of weights for pairs of binary
-    variables.
-    """
-    def __init__(self, initial_weights: Dict[Tuple[str, str], float]):
-        self.weight_matrix = {k: v for k, v in initial_weights.items()}
+SelfType = TypeVar("SelfType", bound="BiasAccumulator")
+T = TypeVar("T")
 
-    def add(self, weights_to_add: Dict[Tuple[str, str], float]):
+def _copy_initial(source: Optional[Dict[T, float]]) -> Dict[T, float]:
+    if source is None:
+        return {}
+    return {k: v for k, v in source.items()}
+
+
+class BiasAccumulator:
+    """
+    This class encapsulates the aggregation of weights for linear and quadratic
+    biases of spin variables.
+    """
+    def __init__(
+            self,
+            *,
+            initial_linears: Dict[str, float] = None,
+            initial_quadratics: Dict[Tuple[str, str], float] = None
+        ):
+        self.linear_biases = _copy_initial(initial_linears)
+        self.quadratic_biases = _copy_initial(initial_quadratics)
+
+    def add_linears(self, weights_to_add: Dict[str, float]):
         for k, v in weights_to_add.items():
-            self.weight_matrix[k] = self.weight_matrix.get(k, 0.0) + v
+            self.linear_biases[k] = self.linear_biases.get(k, 0.0) + v
+
+    def add_quadratics(self, weights_to_add: Dict[Tuple[str, str], float]):
+        for k, v in weights_to_add.items():
+            self.quadratic_biases[k] = self.linear_biases.get(k, 0.0) + v
+
+    def add(self, other: SelfType):
+        self.add_linears(other.linear_biases)
+        self.add_quadratics(other.quadratic_biases)


### PR DESCRIPTION
Even though Ocean will turn it into QUBO internally, formulating everything with spin variables makes it easy to compare with ACS.