### PR TITLE
Correct example-generator and comparison code

### DIFF
--- a/comparison/cosmotransitions.py
+++ b/comparison/cosmotransitions.py
@@ -8,10 +8,11 @@ from potential import CtPotential
 
 def for_single_field(ct_potential: CtPotential):
     bubble_profile = SingleFieldInstanton(
-        -1.0,
-        1.0,
-        ct_potential.get_single_field_potential(),
-        ct_potential.get_single_field_gradient()
+        phi_absMin=-1.0,
+        phi_metaMin=1.0,
+        V=ct_potential.get_single_field_potential(),
+        dV=ct_potential.get_single_field_gradient(),
+        alpha=3
     ).findProfile()
 
     content_for_CSV = (

--- a/comparison/parameters.py
+++ b/comparison/parameters.py
@@ -32,8 +32,8 @@ def for_model(
         )
     elif model_name == "acs":
         return for_ACS(
-            N=20,
-            M=20,
+            N=50,
+            M=50,
             epsilon=0.01,
             has_second_field=has_second_field
         )
@@ -171,7 +171,7 @@ def for_ACS(
             phi_squared_minus_one = (phi * phi) - 1.0
             return (
                 (0.125 * phi_squared_minus_one * phi_squared_minus_one)
-                + (epsilon * (phi - 1.0))
+                + (0.5 * epsilon * (phi - 1.0))
             )
 
         return ExampleModelParameters(
@@ -216,7 +216,7 @@ def for_ACS(
         phi_squared_minus_one = phi_squared - 1.0
         purely_phi = (
             (0.125 * phi_squared_minus_one * phi_squared_minus_one)
-            + (epsilon * (phi - 1.0))
+            + (0.5 * epsilon * (phi - 1.0))
         )
         psi_squared = (psi * psi)
         purely_psi = (


### PR DESCRIPTION
The parameters for the ACS case were incorrect by a factor of 2, and the Cosmotransitions comparison was for the thermal tunneling case, which is not the correct comparison.