### PR TITLE
Extend the README with observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ PYTHONPATH=/path/to/cosmotransitions/ python3 cosmotransitions.py --model_name a
 
 for parameters used in https://arxiv.org/abs/2003.07374 extended to using a
 second field (but not the U(1) string case described in that paper).
+
+
+# Notes
+
+Please be aware that the implementation here wastes 2 qubits per word because I
+did not pay enough attention to the original Ising-chain domain wall paper,
+where the fixed initial |1> and fixed final |0> are left out as fictitious.
+
+Furthermore, the objective function minimized by this program is actually the
+integral of the Hamiltonian all multiplied by a constant factor of the inverse
+of the lattice spacing. This does not affect the resulting bubble profile, but
+the energy of the sample needs to be scaled as well as having the contributions
+from the extra ICDW-enforcing and bubble-center-and-edge-fixing terms removed.


### PR DESCRIPTION
After revisiting the literature, I discovered that I could have left the fixed end qubits of each word as fictitious. I also noticed that I did not correctly turn the integral into a sum, because I neglected the factor of the lattice spacing per term. Fortunately, the lattice spacing is constant in the cases in the program and does not affect the minimization. The final value of the minimized objective function is already a mess because of the extra terms enforcing ICDW and the bubble center and edge being at the true vacuum and false vacuum respectively, so it is really not important to correct. I feel that it is sufficient to just make these observations in the README.